### PR TITLE
Proposes menu nav item "Co-Lab Repos".

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -68,6 +68,7 @@
 									<a class="item{{if .PageIsHome}} active{{end}}" href="{{AppSubUrl}}/">{{.i18n.Tr "home"}}</a>
 								{{end}}
 
+								<a class="item" href="{{AppSubUrl}}/Co-Lab">Co-Lab Repos</a>
 								<a class="item{{if .PageIsExplore}} active{{end}}" href="{{AppSubUrl}}/explore/repos">{{.i18n.Tr "explore"}}</a>
 								{{/*<div class="item">
 									<div class="ui icon input">


### PR DESCRIPTION
It may be confusing to the normal user that the Explore page lists all Co-Lab repos with forks and other repos. Although is also interesting having those, this change proposes having two links, "Co-Labs Repos" for the "official" Co-Lab repos. And aside the existing "Explore" (maybe changing name).

I've not tested the change, just orientative. There should be added "{{if .PageIsExplore}} active{{end}}" with the right conditional for this item, and maybe (maybe not) the translation string for "Co-Lab Repos".
(Is needed to re-build some files from templates?)